### PR TITLE
Allow specific adapters to decide how to decode their Config settings

### DIFF
--- a/api/dashboards/83bb72a2-2aa1-4616-9e03-68bcd2b562ff.json
+++ b/api/dashboards/83bb72a2-2aa1-4616-9e03-68bcd2b562ff.json
@@ -26,8 +26,8 @@
             "adapter": {
                 "type_": "METRIC",
                 "config": {
-                    "sourceCell": [1, 1],
-                    "targetCell": [1, 2]
+                    "sourceCell": [1, 0],
+                    "targetCell": [2, 1]
                 }
             },
             "renderer": "METRIC",

--- a/src/Data/Widget/Adapters/Adapter.elm
+++ b/src/Data/Widget/Adapters/Adapter.elm
@@ -1,19 +1,19 @@
-module Data.Widget.Adapters.Adapter exposing (Adapter(..), decoder)
+module Data.Widget.Adapters.Adapter exposing (Adapter(..), Config, decoder)
 
-import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition, decoder)
+import Data.Widget.Adapters.Config as AdapterConfig
 import Data.Widget.Adapters.MetricAdapter as MetricAdapter
-import Json.Decode as Decode exposing (Decoder, maybe, dict, string)
-import Json.Decode.Pipeline as Pipeline exposing (decode, required, optional)
 import Dict exposing (Dict)
+import Json.Decode as Decode exposing (Decoder, maybe, dict, string, Value)
+import Json.Decode.Pipeline as Pipeline exposing (decode, required, optional)
 
 
 type alias Config =
-    Dict String CellPosition
+    Dict String Value
 
 
 type alias Definition =
     { type_ : String
-    , config : Maybe Config
+    , config : Maybe AdapterConfig.Config
     }
 
 
@@ -21,7 +21,7 @@ type Adapter
     = TABLE
     | BAR_CHART
     | HEAT_MAP
-    | METRIC Config
+    | METRIC AdapterConfig.Config
 
 
 decoder : Decoder Adapter
@@ -51,4 +51,4 @@ definitionDecoder : Decoder Definition
 definitionDecoder =
     decode Definition
         |> required "type_" Decode.string
-        |> optional "config" (maybe (dict CellPosition.decoder)) Nothing
+        |> optional "config" (maybe (Decode.dict Decode.value)) Nothing

--- a/src/Data/Widget/Adapters/CellPosition.elm
+++ b/src/Data/Widget/Adapters/CellPosition.elm
@@ -1,6 +1,7 @@
-module Data.Widget.Adapters.CellPosition exposing (CellPosition, decoder)
+module Data.Widget.Adapters.CellPosition exposing (CellPosition, asJsonValue, decoder)
 
-import Json.Decode as Decode exposing (Decoder, index, int, map2)
+import Json.Decode as Decode exposing (Decoder, index, int, map2, Value)
+import Json.Encode as Encode exposing (int)
 
 
 type alias RowNumber =
@@ -17,4 +18,12 @@ type alias CellPosition =
 
 decoder : Decoder CellPosition
 decoder =
-    map2 (,) (index 0 int) (index 1 int)
+    map2 (,) (index 0 Decode.int) (index 1 Decode.int)
+
+
+asJsonValue : CellPosition -> Decode.Value
+asJsonValue cellPosition =
+    Encode.list
+        [ Encode.int <| Tuple.first cellPosition
+        , Encode.int <| Tuple.second cellPosition
+        ]

--- a/src/Data/Widget/Adapters/Config.elm
+++ b/src/Data/Widget/Adapters/Config.elm
@@ -1,0 +1,8 @@
+module Data.Widget.Adapters.Config exposing (Config)
+
+import Dict exposing (Dict)
+import Json.Decode as Decode exposing (Value)
+
+
+type alias Config =
+    Dict String Value

--- a/src/Data/Widget/Adapters/MetricAdapter.elm
+++ b/src/Data/Widget/Adapters/MetricAdapter.elm
@@ -1,24 +1,30 @@
 module Data.Widget.Adapters.MetricAdapter exposing (defaultConfig, adapt)
 
-import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition, decoder)
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition, asJsonValue, decoder)
+import Data.Widget.Adapters.Config as AdapterConfig
 import Data.Widget.Table as Table exposing (Data)
 import Array
 import Dict exposing (Dict)
+import Json.Decode as Json exposing (Value)
+import Json.Encode as Encode exposing (..)
 
 
-defaultSourceCellPosition : CellPosition
-defaultSourceCellPosition =
+sourceCellPosition : CellPosition
+sourceCellPosition =
     ( 0, 0 )
 
 
-defaultTargetCellPosition : CellPosition
-defaultTargetCellPosition =
+targetCellPosition : CellPosition
+targetCellPosition =
     ( 0, 1 )
 
 
-defaultConfig : Dict String CellPosition
+defaultConfig : Dict String Json.Value
 defaultConfig =
-    Dict.fromList [ ( "sourceCell", defaultSourceCellPosition ), ( "targetCell", defaultTargetCellPosition ) ]
+    Dict.fromList
+        [ ( "sourceCell", CellPosition.asJsonValue sourceCellPosition )
+        , ( "targetCell", CellPosition.asJsonValue targetCellPosition )
+        ]
 
 
 rowForCell : Array.Array (List String) -> CellPosition -> List String
@@ -45,16 +51,28 @@ valueForCell rows cell =
                 ""
 
 
-adapt : Dict String CellPosition -> Data -> ( String, String )
-adapt config data =
+adapt : AdapterConfig.Config -> Data -> ( String, String )
+adapt optionalConfig data =
     let
         rows =
             Array.fromList data.rows
 
+        sourceCell =
+            Dict.get "sourceCell" optionalConfig
+                |> Maybe.withDefault (CellPosition.asJsonValue sourceCellPosition)
+                |> Json.decodeValue CellPosition.decoder
+                |> Result.withDefault sourceCellPosition
+
+        targetCell =
+            Dict.get "targetCell" optionalConfig
+                |> Maybe.withDefault (CellPosition.asJsonValue targetCellPosition)
+                |> Json.decodeValue CellPosition.decoder
+                |> Result.withDefault targetCellPosition
+
         sourceValue =
-            valueForCell rows (Maybe.withDefault defaultSourceCellPosition (Dict.get "sourceCell" config))
+            valueForCell rows sourceCell
 
         targetValue =
-            valueForCell rows (Maybe.withDefault defaultTargetCellPosition (Dict.get "targetCell" config))
+            valueForCell rows targetCell
     in
         ( sourceValue, targetValue )

--- a/tests/Data/Widget/Adapters/AdapterDecoderTest.elm
+++ b/tests/Data/Widget/Adapters/AdapterDecoderTest.elm
@@ -2,8 +2,10 @@ module Data.Widget.Adapters.AdapterDecoderTest exposing (..)
 
 import Expect exposing (Expectation)
 import Data.Widget.Adapters.Adapter as Adapter exposing (Adapter(..))
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (..)
 import Data.Widget.Adapters.MetricAdapter as MetricAdapter exposing (defaultConfig)
 import Json.Decode as Decode exposing (..)
+import Json.Encode as Encode exposing (..)
 import Test exposing (..)
 import Dict exposing (Dict)
 
@@ -41,11 +43,22 @@ adapterDecoderTest =
 
                         }
                         """
+
+                    expectedSourceCell =
+                        CellPosition.asJsonValue ( 1, 1 )
+
+                    expectedTargetCell =
+                        CellPosition.asJsonValue ( 1, 3 )
                 in
                     Expect.equal
                         (Decode.decodeString Adapter.decoder input)
                         (Ok
-                            (Adapter.METRIC <| Dict.fromList [ ( "sourceCell", ( 1, 1 ) ), ( "targetCell", ( 1, 3 ) ) ])
+                            (Adapter.METRIC <|
+                                Dict.fromList
+                                    [ ( "sourceCell", expectedSourceCell )
+                                    , ( "targetCell", expectedTargetCell )
+                                    ]
+                            )
                         )
     in
         Test.describe "Adapter.decode"

--- a/tests/Data/Widget/Adapters/MetricAdapterTest.elm
+++ b/tests/Data/Widget/Adapters/MetricAdapterTest.elm
@@ -3,9 +3,11 @@ module Data.Widget.Adapters.MetricAdapterTest exposing (..)
 import Expect exposing (Expectation)
 import Test exposing (..)
 import Data.Widget.Adapters.AdapterTestData as TD
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (..)
 import Data.Widget.Adapters.MetricAdapter as MetricAdapter exposing (adapt)
 import Data.Widget.Table as Table exposing (Data)
 import Dict exposing (Dict)
+import Json.Encode as Encode exposing (..)
 
 
 adapterConfigTest : Test
@@ -24,8 +26,17 @@ adapterConfigTest =
         defaultConfig =
             MetricAdapter.defaultConfig
 
+        suppliedConfigSource =
+            CellPosition.asJsonValue ( 1, 1 )
+
+        suppliedConfigTarget =
+            CellPosition.asJsonValue ( 2, 1 )
+
         suppliedConfig =
-            Dict.fromList [ ( "sourceCell", ( 1, 1 ) ), ( "targetCell", ( 2, 1 ) ) ]
+            Dict.fromList
+                [ ( "sourceCell", suppliedConfigSource )
+                , ( "targetCell", suppliedConfigTarget )
+                ]
 
         -- function under test!
         ( defaultActualSourceFigure, defaultActualTargetFigure ) =


### PR DESCRIPTION
Now that Config is a generic Dict, make no assumption about the contents of that Config when decoding a Definition. 

Instead, pass the raw JSON `Value` (an un-encoded data type) into the specific decoder and let that decide what it expects and what to do if there's no config present.

This adds a slight overhead in the specific adapter (e.g. [MetricAdapter.adapt](https://github.com/energizedwork/ew-dashboards-ui/compare/rc-metrics...msp-rc-metrics?expand=1#diff-d7b79472869d00ef22dd02ee654f2895R62)) where it must box and unbox the raw position data to deal with Maybes but it'll give us the flexibility we need.

Thoughts @robwebdev ?