### PR TITLE
Use product types for CellPosition & make CellRange explicit

### DIFF
--- a/api/dashboards/83bb72a2-2aa1-4616-9e03-68bcd2b562ff.json
+++ b/api/dashboards/83bb72a2-2aa1-4616-9e03-68bcd2b562ff.json
@@ -146,7 +146,10 @@
       "adapter": {
         "type_": "BAR_CHART",
         "config": {
-          "bodyRows": [[1, 2], [12, 3]],
+          "bodyRows": {
+            "start": [1, 2],
+            "end": [12, 3]
+          },
           "xLabelsIndex": 1
         }
 

--- a/src/Data/Widget/Adapters/Adapter.elm
+++ b/src/Data/Widget/Adapters/Adapter.elm
@@ -57,4 +57,8 @@ definitionDecoder : Decoder Definition
 definitionDecoder =
     decode Definition
         |> required "type_" Decode.string
-        |> optional "config" (maybe (Decode.dict Decode.value)) Nothing
+        |> optional "config"
+            (maybe
+                (Decode.dict Decode.value)
+            )
+            Nothing

--- a/src/Data/Widget/Adapters/CellPosition.elm
+++ b/src/Data/Widget/Adapters/CellPosition.elm
@@ -1,29 +1,34 @@
-module Data.Widget.Adapters.CellPosition exposing (CellPosition, asJsonValue, decoder)
+module Data.Widget.Adapters.CellPosition exposing (CellPosition(..), x, y, encode, decoder)
 
-import Json.Decode as Decode exposing (Decoder, index, int, map2, Value)
+import Json.Decode as Decode exposing (Decoder, Value, index, int, map2)
 import Json.Encode as Encode exposing (int)
+import Tuple exposing (..)
 
 
-type alias RowNumber =
-    Int
-
-
-type alias ColumnNumber =
-    Int
-
-
-type alias CellPosition =
-    ( RowNumber, ColumnNumber )
+type CellPosition
+    = CellPosition ( Int, Int )
 
 
 decoder : Decoder CellPosition
 decoder =
-    map2 (,) (index 0 Decode.int) (index 1 Decode.int)
+    Decode.map2 (,) (index 0 Decode.int) (index 1 Decode.int)
+        |> Decode.andThen
+            (\( x, y ) -> Decode.succeed <| CellPosition ( x, y ))
 
 
-asJsonValue : CellPosition -> Decode.Value
-asJsonValue cellPosition =
+encode : CellPosition -> Decode.Value
+encode cellPosition =
     Encode.list
-        [ Encode.int <| Tuple.first cellPosition
-        , Encode.int <| Tuple.second cellPosition
+        [ Encode.int <| x cellPosition
+        , Encode.int <| y cellPosition
         ]
+
+
+x : CellPosition -> Int
+x (CellPosition position) =
+    Tuple.first position
+
+
+y : CellPosition -> Int
+y (CellPosition position) =
+    Tuple.second position

--- a/src/Data/Widget/Adapters/LineAndBarAdapter.elm
+++ b/src/Data/Widget/Adapters/LineAndBarAdapter.elm
@@ -1,7 +1,7 @@
 module Data.Widget.Adapters.LineAndBarAdapter exposing (defaultConfig, adapt)
 
 import Array
-import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition, asJsonValue, decoder)
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition, encode, decoder)
 import Data.Widget.Adapters.CellRange as CellRange exposing (..)
 import Data.Widget.Adapters.Config as AdapterConfig
 import Data.Widget.Adapters.TableAdapter as TableAdapter exposing (..)

--- a/src/Data/Widget/Adapters/MetricAdapter.elm
+++ b/src/Data/Widget/Adapters/MetricAdapter.elm
@@ -1,6 +1,6 @@
 module Data.Widget.Adapters.MetricAdapter exposing (defaultConfig, adapt)
 
-import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition, asJsonValue, decoder)
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition(..), encode, decoder)
 import Data.Widget.Adapters.Config as AdapterConfig
 import Data.Widget.Table as Table exposing (Data)
 import Array
@@ -10,25 +10,25 @@ import Json.Decode as Json exposing (Value)
 
 sourceCellPosition : CellPosition
 sourceCellPosition =
-    ( 0, 0 )
+    CellPosition ( 0, 0 )
 
 
 targetCellPosition : CellPosition
 targetCellPosition =
-    ( 0, 1 )
+    CellPosition ( 0, 1 )
 
 
 defaultConfig : Dict String Json.Value
 defaultConfig =
     Dict.fromList
-        [ ( "sourceCell", CellPosition.asJsonValue sourceCellPosition )
-        , ( "targetCell", CellPosition.asJsonValue targetCellPosition )
+        [ ( "sourceCell", CellPosition.encode sourceCellPosition )
+        , ( "targetCell", CellPosition.encode targetCellPosition )
         ]
 
 
 rowForCell : Array.Array (List String) -> CellPosition -> List String
-rowForCell rows cellConfig =
-    case Array.get (Tuple.first cellConfig) rows of
+rowForCell rows cellPosition =
+    case Array.get (CellPosition.x cellPosition) rows of
         Just row ->
             row
 
@@ -37,12 +37,12 @@ rowForCell rows cellConfig =
 
 
 valueForCell : Array.Array (List String) -> CellPosition -> String
-valueForCell rows cell =
+valueForCell rows cellPosition =
     let
         row =
-            rowForCell rows cell
+            rowForCell rows cellPosition
     in
-        case Array.get (Tuple.second cell) (Array.fromList row) of
+        case Array.get (CellPosition.y cellPosition) (Array.fromList row) of
             Just value ->
                 value
 
@@ -58,13 +58,13 @@ adapt optionalConfig data =
 
         sourceCell =
             Dict.get "sourceCell" optionalConfig
-                |> Maybe.withDefault (CellPosition.asJsonValue sourceCellPosition)
+                |> Maybe.withDefault (CellPosition.encode sourceCellPosition)
                 |> Json.decodeValue CellPosition.decoder
                 |> Result.withDefault sourceCellPosition
 
         targetCell =
             Dict.get "targetCell" optionalConfig
-                |> Maybe.withDefault (CellPosition.asJsonValue targetCellPosition)
+                |> Maybe.withDefault (CellPosition.encode targetCellPosition)
                 |> Json.decodeValue CellPosition.decoder
                 |> Result.withDefault targetCellPosition
 

--- a/src/Data/Widget/Adapters/TableAdapter.elm
+++ b/src/Data/Widget/Adapters/TableAdapter.elm
@@ -1,8 +1,9 @@
 module Data.Widget.Adapters.TableAdapter exposing (defaultConfig, adapt)
 
+import Data.Widget.Adapters.CellPosition exposing (CellPosition(..))
 import Data.Widget.Adapters.CellRange as CellRange exposing (..)
 import Data.Widget.Adapters.Config as AdapterConfig
-import Data.Widget.Table as Table exposing (Data, Row, Cell)
+import Data.Widget.Table as Table exposing (Cell, Data, Row)
 import Dict exposing (Dict)
 import Json.Decode as Json exposing (Value)
 import Json.Encode as Encode exposing (Value)
@@ -18,13 +19,24 @@ xLabelsIndex =
 -- Possible values:
 -- "bodyRows"
 -- "xLabelsIndex"
+-- TODO Change to use CellRange, not an index
 
 
 defaultConfig : Dict String Json.Value
 defaultConfig =
     Dict.fromList
-        [ ( "xLabelsIndex", Encode.int xLabelsIndex )
-        ]
+        [ ( "xLabelsIndex", Encode.int xLabelsIndex ) ]
+
+
+
+-- Dict.fromList
+--     [ ( "xLabels"
+--       , CellRange.encode <|
+--             CellRange
+--                 (CellPosition ( 1, 1 ))
+--                 (CellPosition ( 10, 1 ))
+--       )
+--     ]
 
 
 adapt : AdapterConfig.Config -> Data -> ( Row, List Row, Float, Float, List String )
@@ -38,6 +50,7 @@ adapt optionalConfig data =
             )
                 - 1
 
+        -- TODO should be CellRange.extractRows data headerRange
         xLabels =
             case List.Extra.getAt actualXLabelsIndex data.rows of
                 Just xLabel ->
@@ -56,7 +69,11 @@ adapt optionalConfig data =
                         range =
                             bodyRows
                                 |> Json.decodeValue CellRange.decoder
-                                |> Result.withDefault [ ( 1, 1 ), ( 10, 2 ) ]
+                                |> Result.withDefault
+                                    (CellRange
+                                        (CellPosition ( 1, 1 ))
+                                        (CellPosition ( 10, 2 ))
+                                    )
                     in
                         CellRange.extractRows data range
 

--- a/tests/Data/Widget/Adapters/AdapterDecoderTest.elm
+++ b/tests/Data/Widget/Adapters/AdapterDecoderTest.elm
@@ -45,10 +45,10 @@ adapterDecoderTest =
                         """
 
                     expectedSourceCell =
-                        CellPosition.asJsonValue ( 1, 1 )
+                        CellPosition.encode <| CellPosition ( 1, 1 )
 
                     expectedTargetCell =
-                        CellPosition.asJsonValue ( 1, 3 )
+                        CellPosition.encode <| CellPosition ( 1, 3 )
                 in
                     Expect.equal
                         (Decode.decodeString Adapter.decoder input)

--- a/tests/Data/Widget/Adapters/CellPositionTest.elm
+++ b/tests/Data/Widget/Adapters/CellPositionTest.elm
@@ -1,0 +1,51 @@
+module Data.Widget.Adapters.CellPositionTest exposing (..)
+
+import Data.Widget.Adapters.AdapterTestData as TD
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition(..), encode)
+import Data.Widget.Adapters.CellRange exposing (CellRange)
+import Data.Widget.Adapters.LineAndBarAdapter as LineAndBarAdapter exposing (adapt)
+import Data.Widget.Table as Table exposing (Data)
+import Dict exposing (Dict)
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Json.Decode as Decode exposing (..)
+import Json.Encode as Encode exposing (..)
+import List.Extra
+import Test exposing (..)
+
+
+decoderTest : Test
+decoderTest =
+    let
+        input =
+            """
+            [20, 4]
+            """
+
+        runDecode =
+            \_ ->
+                Decode.decodeString (CellPosition.decoder) input
+                    |> Expect.equal
+                        (Ok <|
+                            CellPosition ( 20, 4 )
+                        )
+    in
+        Test.describe "CellPosition"
+            [ Test.test "decoder" runDecode
+            ]
+
+
+encoderTest : Test
+encoderTest =
+    let
+        input =
+            CellPosition ( 1, 5 )
+
+        runEncode =
+            \_ ->
+                (toString <| CellPosition.encode input)
+                    |> Expect.equal "{ 0 = 1, 1 = 5 }"
+    in
+        Test.describe "CellPosition encode"
+            [ Test.test "encode" runEncode
+            ]

--- a/tests/Data/Widget/Adapters/LineAndBarAdapterTest.elm
+++ b/tests/Data/Widget/Adapters/LineAndBarAdapterTest.elm
@@ -1,8 +1,8 @@
 module Data.Widget.Adapters.LineAndBarAdapterTest exposing (..)
 
 import Data.Widget.Adapters.AdapterTestData as TD
-import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition, asJsonValue, decoder)
-import Data.Widget.Adapters.CellRange as CellRange exposing (asJsonValue)
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition(..), encode, decoder)
+import Data.Widget.Adapters.CellRange as CellRange exposing (CellRange, encode)
 import Data.Widget.Adapters.LineAndBarAdapter as LineAndBarAdapter exposing (adapt)
 import Data.Widget.Table as Table exposing (Data)
 import Dict exposing (Dict)
@@ -31,8 +31,18 @@ adapterConfigTest =
 
         suppliedConfig =
             Dict.fromList
-                [ ( "lineRows", CellRange.asJsonValue [ ( 5, 2 ), ( 10, 3 ) ] )
-                , ( "barRows", CellRange.asJsonValue [ ( 5, 4 ), ( 10, 5 ) ] )
+                [ ( "lineRows"
+                  , CellRange.encode <|
+                        CellRange
+                            (CellPosition ( 5, 2 ))
+                            (CellPosition ( 10, 3 ))
+                  )
+                , ( "barRows"
+                  , CellRange.encode <|
+                        CellRange
+                            (CellPosition ( 5, 4 ))
+                            (CellPosition ( 10, 5 ))
+                  )
                 , ( "xLabelsIndex", Encode.int 3 )
                 ]
 

--- a/tests/Data/Widget/Adapters/MetricAdapterTest.elm
+++ b/tests/Data/Widget/Adapters/MetricAdapterTest.elm
@@ -27,10 +27,10 @@ adapterConfigTest =
             MetricAdapter.defaultConfig
 
         suppliedConfigSource =
-            CellPosition.asJsonValue ( 1, 1 )
+            CellPosition.encode <| CellPosition ( 1, 1 )
 
         suppliedConfigTarget =
-            CellPosition.asJsonValue ( 2, 1 )
+            CellPosition.encode <| CellPosition ( 2, 1 )
 
         suppliedConfig =
             Dict.fromList

--- a/tests/Data/Widget/Adapters/TableAdapterTest.elm
+++ b/tests/Data/Widget/Adapters/TableAdapterTest.elm
@@ -1,8 +1,8 @@
 module Data.Widget.Adapters.TableAdapterTest exposing (..)
 
 import Data.Widget.Adapters.AdapterTestData as TD
-import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition, asJsonValue, decoder)
-import Data.Widget.Adapters.CellRange as CellRange exposing (asJsonValue)
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition(..), encode, decoder)
+import Data.Widget.Adapters.CellRange as CellRange exposing (CellRange, encode)
 import Data.Widget.Adapters.TableAdapter as TableAdapter exposing (adapt)
 import Data.Widget.Table as Table exposing (Data)
 import Dict exposing (Dict)
@@ -31,7 +31,12 @@ adapterConfigTest =
 
         suppliedConfig =
             Dict.fromList
-                [ ( "bodyRows", CellRange.asJsonValue [ ( 5, 2 ), ( 10, 3 ) ] )
+                [ ( "bodyRows"
+                  , CellRange.encode <|
+                        CellRange
+                            (CellPosition ( 5, 2 ))
+                            (CellPosition ( 10, 3 ))
+                  )
                 , ( "xLabelsIndex", Encode.int 3 )
                 ]
 
@@ -66,8 +71,13 @@ adapterConfigTest =
             \_ -> defaultActualXLabels |> Expect.equal TD.headerRow
 
         suppliedHeaders =
-            \_ -> suppliedActualHeaderRow |> Expect.equal TD.secondRow
+            \_ ->
+                suppliedActualHeaderRow |> Expect.equal TD.secondRow
 
+        -- TODO incorrect expectation above, correct below!
+        -- suppliedActualHeaderRow
+        --     |> Expect.equal
+        --         [ "205", "206", "207", "208", "209", "210" ]
         suppliedLineChartRows =
             \_ ->
                 suppliedActualBodyRows
@@ -95,7 +105,7 @@ adapterConfigTest =
                 ]
             , Test.describe "with supplied Config"
                 [ Test.test "headers are third row" suppliedHeaders
-                , Test.test "body chart rows are as specified" suppliedLineChartRows
+                , Test.test "body rows are as specified" suppliedLineChartRows
                 , Test.test "min value is extracted from body rows" suppliedMinValue
                 , Test.test "max value is extracted from body rows" suppliedMaxValue
                 , Test.test "x-axis labels are as specified" suppliedXLabels


### PR DESCRIPTION
Best explained in the TiL:

https://til.energizedwork.com/posts/udozfe00ou-type-alias-vs-union-types

@robwebdev - this explains your earlier comment https://github.com/energizedwork/ew-dashboards-ui/commit/e8deaa0617176f772d6f7a775f7dba51941331fb#diff-3542a7545070827f6431070341ee0601R20