### PR TITLE
Express LineAndBarChart JSON in the same form as the individual charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log
 
 dataSourcesProd.txt
 bak.json
+tmp.json

--- a/api/dashboards/04b3929f-2f3f-4d5a-beb1-be8336989992.json
+++ b/api/dashboards/04b3929f-2f3f-4d5a-beb1-be8336989992.json
@@ -25,29 +25,37 @@
         "adapter": {
           "type_": "LINE_AND_BAR_CHART",
           "config": {
-            "xLabels": {
-              "start": [2, 18],
-              "end": [9, 18]
+            "line": {
+              "xLabels": {
+                "start": [2, 18],
+                "end": [9, 18]
+              },
+              "bodyRows": {
+                "start": [2, 22],
+                "end": [9, 23]
+              },
+              "seriesLabels": {
+                "start": [1, 22],
+                "end": [1, 23]
+              },
+              "yAxisLabel": [3, 16],
+              "xAxisLabel": [5, 15]
             },
-            "barRows": {
-              "start": [2, 19],
-              "end": [9, 21]
-            },
-            "barSeriesLabels": {
-              "start": [1, 19],
-              "end": [1, 21]
-            },
-            "lineRows": {
-              "start": [2, 22],
-              "end": [9, 23]
-            },
-            "lineSeriesLabels": {
-              "start": [1, 22],
-              "end": [1, 23]
-            },
-            "barYAxisLabel": [3, 15],
-            "lineYAxisLabel": [3, 16],
-            "lineXAxisLabel": [5, 15]
+            "bar": {
+              "xLabels": {
+                "start": [2, 18],
+                "end": [9, 18]
+              },
+              "bodyRows": {
+                "start": [2, 19],
+                "end": [9, 21]
+              },
+              "seriesLabels": {
+                "start": [1, 19],
+                "end": [1, 21]
+              },
+              "yAxisLabel": [3, 15]
+            }
           }
         },
         "renderer": {

--- a/api/dashboards/20fa7de1-ff2b-47fe-8295-989dae863561.json
+++ b/api/dashboards/20fa7de1-ff2b-47fe-8295-989dae863561.json
@@ -25,29 +25,37 @@
         "adapter": {
           "type_": "LINE_AND_BAR_CHART",
           "config": {
-            "xLabels": {
-              "start": [2, 58],
-              "end": [13, 58]
+            "line": {
+              "xLabels": {
+                "start": [2, 58],
+                "end": [13, 58]
+              },
+              "bodyRows": {
+                "start": [2, 62],
+                "end": [13, 63]
+              },
+              "seriesLabels": {
+                "start": [1, 62],
+                "end": [1, 63]
+              },
+              "yAxisLabel": [3, 56],
+              "xAxisLabel": [5, 55]
             },
-            "barRows": {
-              "start": [2, 59],
-              "end": [13, 61]
-            },
-            "barSeriesLabels": {
-              "start": [1, 59],
-              "end": [1, 61]
-            },
-            "lineRows": {
-              "start": [2, 62],
-              "end": [13, 63]
-            },
-            "lineSeriesLabels": {
-              "start": [1, 62],
-              "end": [1, 63]
-            },
-            "barYAxisLabel": [3, 55],
-            "lineYAxisLabel": [3, 56],
-            "lineXAxisLabel": [5, 55]
+            "bar": {
+              "xLabels": {
+                "start": [2, 58],
+                "end": [13, 58]
+              },
+              "bodyRows": {
+                "start": [2, 59],
+                "end": [13, 61]
+              },
+              "seriesLabels": {
+                "start": [1, 59],
+                "end": [1, 61]
+              },
+              "barYAxisLabel": [3, 55]
+            }
           }
         },
         "renderer": {

--- a/api/dashboards/3b815b92-c716-4896-b9c3-e98255718aeb.json
+++ b/api/dashboards/3b815b92-c716-4896-b9c3-e98255718aeb.json
@@ -192,29 +192,37 @@
         "adapter": {
           "type_": "LINE_AND_BAR_CHART",
           "config": {
-            "xLabels": {
-              "start": [2, 103],
-              "end": [6, 103]
+            "line": {
+              "bodyRows": {
+                "start": [2, 107],
+                "end": [6, 108]
+              },
+              "seriesLabels": {
+                "start": [1, 107],
+                "end": [1, 108]
+              },
+              "xLabels": {
+                "start": [2, 103],
+                "end": [6, 103]
+              },
+              "yAxisLabel": [3, 101],
+              "xAxisLabel": [5, 100]
             },
-            "barRows": {
-              "start": [2, 104],
-              "end": [6, 106]
-            },
-            "barSeriesLabels": {
-              "start": [1, 104],
-              "end": [1, 106]
-            },
-            "lineRows": {
-              "start": [2, 107],
-              "end": [6, 108]
-            },
-            "lineSeriesLabels": {
-              "start": [1, 107],
-              "end": [1, 108]
-            },
-            "barYAxisLabel": [3, 100],
-            "lineYAxisLabel": [3, 101],
-            "lineXAxisLabel": [5, 100]
+            "bar": {
+              "bodyRows": {
+                "start": [2, 104],
+                "end": [6, 106]
+              },
+              "seriesLabels": {
+                "start": [1, 104],
+                "end": [1, 106]
+              },
+              "xLabels": {
+                "start": [2, 103],
+                "end": [6, 103]
+              },
+              "yAxisLabel": [3, 100]
+            }
           }
         },
         "renderer": {

--- a/src/Data/Widget/Adapters/Adapter.elm
+++ b/src/Data/Widget/Adapters/Adapter.elm
@@ -6,6 +6,9 @@ import Data.Widget.Definition as Definition exposing (decoder)
 import Json.Decode as Decode exposing (Decoder, Value, dict, maybe, string)
 
 
+-- Public ----------------------------------------------------------------------
+
+
 type Adapter
     = TABLE AdapterConfig.Config
     | CHART AdapterConfig.Config
@@ -56,3 +59,7 @@ decoder =
                     somethingElse ->
                         Decode.fail <| "Unknown adapter: " ++ somethingElse
             )
+
+
+
+-- Private ---------------------------------------------------------------------

--- a/src/Data/Widget/Adapters/ChartAdapter.elm
+++ b/src/Data/Widget/Adapters/ChartAdapter.elm
@@ -18,9 +18,35 @@ import Json.Decode as Json exposing (Value)
 import Util
 
 
+-- Public ----------------------------------------------------------------------
+
+
 defaultConfig : Dict String Json.Value
 defaultConfig =
     Dict.empty
+
+
+adapt : AdapterConfig.Config -> Data -> Orientation -> Chart.Data
+adapt optionalConfig data orientation =
+    let
+        tableData =
+            TableAdapter.adapt optionalConfig data orientation
+
+        chartData =
+            { tableData
+                | seriesLabels =
+                    extractSeriesLabels optionalConfig data
+                , xAxisLabel =
+                    extractXAxisLabel optionalConfig data
+                , yAxisLabel =
+                    extractYAxisLabel optionalConfig data
+                , forecastPosition =
+                    extractCellPosition "forecastPosition" optionalConfig data
+                        |> Maybe.map String.toInt
+                        |> Maybe.map (Result.withDefault 0)
+            }
+    in
+        chartData
 
 
 extractSeriesLabels : Dict String Json.Value -> Table.Data -> Maybe Table.Cells
@@ -55,6 +81,10 @@ extractYAxisLabel config data =
     extractCellPosition "yAxisLabel" config data
 
 
+
+-- Private ----------------------------------------------------------------------
+
+
 extractCellPosition : String -> Dict String Json.Value -> Table.Data -> Maybe Cell
 extractCellPosition configKey config data =
     case Dict.get configKey config of
@@ -72,26 +102,3 @@ extractCellPosition configKey config data =
 
         Nothing ->
             Nothing
-
-
-adapt : AdapterConfig.Config -> Data -> Orientation -> Chart.Data
-adapt optionalConfig data orientation =
-    let
-        tableData =
-            TableAdapter.adapt optionalConfig data orientation
-
-        chartData =
-            { tableData
-                | seriesLabels =
-                    extractSeriesLabels optionalConfig data
-                , xAxisLabel =
-                    extractXAxisLabel optionalConfig data
-                , yAxisLabel =
-                    extractYAxisLabel optionalConfig data
-                , forecastPosition =
-                    extractCellPosition "forecastPosition" optionalConfig data
-                        |> Maybe.map String.toInt
-                        |> Maybe.map (Result.withDefault 0)
-            }
-    in
-        chartData

--- a/src/Data/Widget/Adapters/LineAndBarAdapter.elm
+++ b/src/Data/Widget/Adapters/LineAndBarAdapter.elm
@@ -1,22 +1,36 @@
-module Data.Widget.Adapters.LineAndBarAdapter exposing (defaultConfig, adapt)
+module Data.Widget.Adapters.LineAndBarAdapter exposing (adapt, defaultConfig)
 
-import Data.Widget.Config as AdapterConfig
 import Data.Widget.Adapters.ChartAdapter as ChartAdapter exposing (..)
 import Data.Widget.Adapters.TableAdapter exposing (Orientation(..))
 import Data.Widget.Chart as Chart exposing (Data)
+import Data.Widget.Config as AdapterConfig
 import Data.Widget.Table as Table exposing (Cell, Data, Row)
 import Dict exposing (Dict)
-import Json.Decode as Json exposing (Value)
+import Json.Decode as Json exposing (..)
 
 
--- Possible values:
--- "lineRows"
--- "lineSeriesLabels"
--- "barRows"
--- "barSeriesLabels"
--- "xLabels"
--- "xAxisLabel"
--- "yAxisLabel"
+-- Public ----------------------------------------------------------------------
+
+
+adapt : AdapterConfig.Config -> Table.Data -> ( Chart.Data, Chart.Data )
+adapt combinedConfig data =
+    let
+        -- TODO
+        -- Certain config should be able to override specific bar or chart config
+        -- at top level in JSON e.g. xLabels ?
+        lineChartData =
+            ChartAdapter.adapt
+                (AdapterConfig.at "line" combinedConfig)
+                data
+                Vertical
+
+        barChartData =
+            ChartAdapter.adapt
+                (AdapterConfig.at "bar" combinedConfig)
+                data
+                Vertical
+    in
+        ( lineChartData, barChartData )
 
 
 defaultConfig : Dict String Json.Value
@@ -24,108 +38,5 @@ defaultConfig =
     Dict.empty
 
 
-cleanseConfig : AdapterConfig.Config -> AdapterConfig.Config
-cleanseConfig optionalConfig =
-    optionalConfig
-        |> Dict.remove "lineRows"
-        |> Dict.remove "lineSeriesLabels"
-        |> Dict.remove "lineXAxisLabel"
-        |> Dict.remove "lineYAxisLabel"
-        |> Dict.remove "barRows"
-        |> Dict.remove "barSeriesLabels"
-        |> Dict.remove "barXAxisLabel"
-        |> Dict.remove "barYAxisLabel"
 
-
-normalizeLineChartConfig : AdapterConfig.Config -> Dict String Value
-normalizeLineChartConfig combinedConfig =
-    extractChartConfig combinedConfig "lineRows" "lineSeriesLabels" "lineXAxisLabel" "lineYAxisLabel"
-
-
-normalizeBarChartConfig : AdapterConfig.Config -> Dict String Value
-normalizeBarChartConfig combinedConfig =
-    extractChartConfig combinedConfig "barRows" "barSeriesLabels" "barXAxisLabel" "barYAxisLabel"
-
-
-tempConfig : Maybe Value -> String -> List ( String, Value )
-tempConfig configValue configKey =
-    let
-        cleansedConfig =
-            case configValue of
-                Just configValue ->
-                    Dict.fromList
-                        [ ( configKey, configValue )
-                        ]
-
-                Nothing ->
-                    Dict.empty
-    in
-        Dict.toList cleansedConfig
-
-
-extractChartConfig : AdapterConfig.Config -> String -> String -> String -> String -> Dict String Value
-extractChartConfig combinedConfig rowsKey seriesLabelKey xAxisLabelKey yAxisLabelKey =
-    let
-        rowsRange =
-            Dict.get rowsKey combinedConfig
-
-        seriesLabelsRange =
-            Dict.get seriesLabelKey combinedConfig
-
-        xAxisLabel =
-            Dict.get xAxisLabelKey combinedConfig
-
-        yAxisLabel =
-            Dict.get yAxisLabelKey combinedConfig
-
-        cleansedConfig =
-            cleanseConfig combinedConfig
-
-        tempRowConfig =
-            tempConfig rowsRange "bodyRows"
-
-        tempSeriesLabelConfig =
-            tempConfig seriesLabelsRange "seriesLabels"
-
-        tempXAxisConfig =
-            tempConfig xAxisLabel "xAxisLabel"
-
-        tempYAxisConfig =
-            tempConfig yAxisLabel "yAxisLabel"
-
-        tempChartConfig =
-            List.concat
-                [ tempRowConfig
-                , tempSeriesLabelConfig
-                , tempXAxisConfig
-                , tempYAxisConfig
-                ]
-                |> Dict.fromList
-    in
-        Dict.union
-            tempChartConfig
-            cleansedConfig
-
-
-adapt : AdapterConfig.Config -> Table.Data -> ( Chart.Data, Chart.Data )
-adapt combinedConfig data =
-    let
-        lineChartData =
-            ChartAdapter.adapt
-                (normalizeLineChartConfig combinedConfig)
-                data
-                Vertical
-
-        barChartData =
-            ChartAdapter.adapt
-                (normalizeBarChartConfig combinedConfig)
-                data
-                Vertical
-
-        xAxisLabel =
-            ChartAdapter.extractXAxisLabel combinedConfig data
-
-        yAxisLabel =
-            ChartAdapter.extractYAxisLabel combinedConfig data
-    in
-        ( lineChartData, barChartData )
+-- Private ---------------------------------------------------------------------

--- a/src/Data/Widget/Chart.elm
+++ b/src/Data/Widget/Chart.elm
@@ -1,6 +1,6 @@
 module Data.Widget.Chart exposing (Data)
 
-import Data.Widget.Table exposing (Row, Cell)
+import Data.Widget.Table exposing (Cell, Row)
 
 
 type alias Data =

--- a/src/Data/Widget/Config.elm
+++ b/src/Data/Widget/Config.elm
@@ -1,7 +1,11 @@
-module Data.Widget.Config exposing (Config, default)
+module Data.Widget.Config exposing (at, Config, default, decoder)
 
 import Dict exposing (Dict)
-import Json.Decode as Json exposing (Value)
+import Json.Decode as Json exposing (..)
+import Json.Encode as Encode exposing (object)
+
+
+-- Public ----------------------------------------------------------------------
 
 
 type alias Config =
@@ -11,3 +15,23 @@ type alias Config =
 default : Dict String Json.Value
 default =
     Dict.empty
+
+
+decoder : Decoder Config
+decoder =
+    Json.dict Json.value
+
+
+at : String -> Config -> Config
+at key combinedConfig =
+    let
+        nestedJSON =
+            (Dict.get key combinedConfig)
+                |> Maybe.withDefault (Encode.string "{}")
+    in
+        Json.decodeValue decoder nestedJSON
+            |> Result.withDefault default
+
+
+
+-- Private ---------------------------------------------------------------------

--- a/src/Data/Widget/Definition.elm
+++ b/src/Data/Widget/Definition.elm
@@ -1,14 +1,16 @@
-module Data.Widget.Definition exposing (decoder)
+module Data.Widget.Definition exposing (decoder, Definition)
 
-import Data.Widget.Config as DefinitionConfig
+import Data.Widget.Config as AdapterConfig
 import Json.Decode as Decode exposing (Decoder, Value, dict, maybe, string)
-import Json.Decode.Extra
 import Json.Decode.Pipeline as Pipeline exposing (custom, decode, hardcoded, optional, required)
+
+
+-- Public ----------------------------------------------------------------------
 
 
 type alias Definition =
     { type_ : String
-    , config : Maybe DefinitionConfig.Config
+    , config : Maybe AdapterConfig.Config
     }
 
 
@@ -18,6 +20,10 @@ decoder =
         |> required "type_" Decode.string
         |> optional "config"
             (maybe
-                (Decode.dict Decode.value)
+                AdapterConfig.decoder
             )
             Nothing
+
+
+
+-- Private ---------------------------------------------------------------------

--- a/src/Page/Dashboard.elm
+++ b/src/Page/Dashboard.elm
@@ -455,7 +455,8 @@ update session msg model =
                         []
 
                     joinChannel phxSocket channels commands =
-                        case Debug.log "joinChannel" <| List.head channels of
+                        -- case Debug.log "joinChannel" <| List.head channels of
+                        case List.head channels of
                             Just ( fullChannelName, channel ) ->
                                 let
                                     ( updatedPhxSocket, phxCmd ) =

--- a/src/Views/Widget/Renderers/LineAndBarChart.elm
+++ b/src/Views/Widget/Renderers/LineAndBarChart.elm
@@ -20,12 +20,7 @@ import Visualization.Axis as Axis exposing (defaultOptions)
 import Visualization.Scale as Scale exposing (..)
 
 
-chartPadding : ChartPadding
-chartPadding =
-    { defaultChartPadding
-        | right = ViewConfig.largePadding
-        , totalHorizontal = ViewConfig.largePadding * 2
-    }
+-- Public ----------------------------------------------------------------------
 
 
 render : RendererConfig.Config -> Int -> Int -> Widget -> Table.Data -> Html msg
@@ -59,6 +54,10 @@ render optionalRendererConfig width height widget data =
                 [ Html.text
                     "Sorry, I can only render line/bar combo charts from a LINE_AND_BAR_CHART adapter right now"
                 ]
+
+
+
+-- Private ---------------------------------------------------------------------
 
 
 view : String -> Int -> Int -> Chart.Data -> Chart.Data -> Html msg
@@ -160,3 +159,11 @@ view namespace w h lineChart barChart =
                 , [ ChartAxisLabels.renderRightYAxisLabel w h lineChart.yAxisLabel chartPadding ]
                 ]
             )
+
+
+chartPadding : ChartPadding
+chartPadding =
+    { defaultChartPadding
+        | right = ViewConfig.largePadding
+        , totalHorizontal = ViewConfig.largePadding * 2
+    }

--- a/tests/Data/Widget/Adapters/ChartAdapterTest.elm
+++ b/tests/Data/Widget/Adapters/ChartAdapterTest.elm
@@ -95,7 +95,9 @@ adapterConfigTest =
             \_ -> defaultActualChartData.maxValue |> Expect.equal 412
 
         defaultXLabels =
-            \_ -> defaultActualChartData.xLabels |> Expect.equal (Just TD.headerRow)
+            \_ ->
+                defaultActualChartData.xLabels
+                    |> Expect.equal (Just TD.headerRow)
 
         defaultSeriesLabels =
             \_ ->
@@ -136,7 +138,12 @@ adapterConfigTest =
             \_ -> suppliedActualChartData.maxValue |> Expect.equal 210
 
         suppliedXLabels =
-            \_ -> suppliedActualChartData.xLabels |> Expect.equal (Just [ "205", "206", "207", "208", "209", "210" ])
+            \_ ->
+                suppliedActualChartData.xLabels
+                    |> Expect.equal
+                        (Just
+                            [ "205", "206", "207", "208", "209", "210" ]
+                        )
 
         suppliedSeriesLabels =
             \_ ->

--- a/tests/Data/Widget/Adapters/LineAndBarAdapterTest.elm
+++ b/tests/Data/Widget/Adapters/LineAndBarAdapterTest.elm
@@ -1,13 +1,15 @@
 module Data.Widget.Adapters.LineAndBarAdapterTest exposing (..)
 
 import Data.Widget.Adapters.AdapterTestData as TD
-import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition(..), encode, decoder)
+import Data.Widget.Adapters.CellPosition as CellPosition exposing (CellPosition(..), decoder, encode)
 import Data.Widget.Adapters.CellRange as CellRange exposing (CellRange, encode)
 import Data.Widget.Adapters.LineAndBarAdapter as LineAndBarAdapter exposing (adapt)
+import Data.Widget.Config as AdapterConfig
 import Data.Widget.Table as Table exposing (Data)
 import Dict exposing (Dict)
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
+import Json.Decode as Decode exposing (decodeValue)
 import Json.Encode as Encode exposing (..)
 import List.Extra
 import Test exposing (..)
@@ -38,51 +40,46 @@ adapterConfigTest =
         defaultConfig =
             LineAndBarAdapter.defaultConfig
 
+        suppliedJSONConfig =
+            """
+            {
+              "line": {
+                  "bodyRows": {
+                    "start": [5, 2],
+                    "end": [10, 3]
+                  },
+                  "seriesLabels": {
+                    "start": [13, 2],
+                    "end": [13, 5]
+                  },
+                  "xLabels": {
+                    "start": [5, 3],
+                    "end": [10, 3]
+                  },
+                  "xAxisLabel": [13, 2],
+                  "yAxisLabel": [13, 3]
+              },
+              "bar": {
+                  "bodyRows": {
+                    "start": [5, 4],
+                    "end": [10, 5]
+                  },
+                  "seriesLabels": {
+                    "start": [13, 2],
+                    "end": [13, 5]
+                  },
+                  "xLabels": {
+                    "start": [5, 3],
+                    "end": [10, 3]
+                  },
+                  "yAxisLabel": [13, 4]
+              }
+            }
+            """
+
         suppliedConfig =
-            Dict.fromList
-                [ ( "lineRows"
-                  , CellRange.encode <|
-                        CellRange
-                            (CellPosition ( 5, 2 ))
-                            (CellPosition ( 10, 3 ))
-                  )
-                , ( "lineSeriesLabels"
-                  , CellRange.encode <|
-                        CellRange
-                            (CellPosition ( 13, 2 ))
-                            (CellPosition ( 13, 5 ))
-                  )
-                , ( "barRows"
-                  , CellRange.encode <|
-                        CellRange
-                            (CellPosition ( 5, 4 ))
-                            (CellPosition ( 10, 5 ))
-                  )
-                , ( "barSeriesLabels"
-                  , CellRange.encode <|
-                        CellRange
-                            (CellPosition ( 13, 2 ))
-                            (CellPosition ( 13, 5 ))
-                  )
-                , ( "xLabels"
-                  , CellRange.encode <|
-                        CellRange
-                            (CellPosition ( 5, 3 ))
-                            (CellPosition ( 10, 3 ))
-                  )
-                , ( "lineXAxisLabel"
-                  , CellPosition.encode <|
-                        CellPosition ( 13, 2 )
-                  )
-                , ( "lineYAxisLabel"
-                  , CellPosition.encode <|
-                        CellPosition ( 13, 3 )
-                  )
-                , ( "barYAxisLabel"
-                  , CellPosition.encode <|
-                        CellPosition ( 13, 4 )
-                  )
-                ]
+            Decode.decodeString AdapterConfig.decoder suppliedJSONConfig
+                |> Result.withDefault AdapterConfig.default
 
         -- functions under test!
         ( defaultLineChart, defaultBarChart ) =
@@ -235,7 +232,7 @@ adapterConfigTest =
                 , Test.test "max value is extracted from bar rows" suppliedBarMaxValue
                 , Test.test "x-axis labels are the third row" suppliedXLabels
                 , Test.test "x-axis label is as specified" suppliedXAxisLabel
-                , Test.test "line charty-axis label is as specified" suppliedLineYAxisLabel
-                , Test.test "bar charty-axis label is as specified" suppliedBarYAxisLabel
+                , Test.test "line chart y-axis label is as specified" suppliedLineYAxisLabel
+                , Test.test "bar chart y-axis label is as specified" suppliedBarYAxisLabel
                 ]
             ]


### PR DESCRIPTION
Hey @robwebdev comments welcome.

In short, this is to be consistent in the JSON and allow the adapters to compose better.

from this

```json
{
  "xLabels": {
    "start": [2, 103],
    "end": [6, 103]
  },
  "barRows": {
    "start": [2, 104],
    "end": [6, 106]
  },
  "barSeriesLabels": {
    "start": [1, 104],
    "end": [1, 106]
  },
  "lineRows": {
    "start": [2, 107],
    "end": [6, 108]
  },
  "lineSeriesLabels": {
    "start": [1, 107],
    "end": [1, 108]
  },
  "barYAxisLabel": [3, 100],
  "lineYAxisLabel": [3, 101],
  "lineXAxisLabel": [5, 100]
}

```


to this

```json
{
  "line": {
      "bodyRows": {
        "start": [5, 2],
        "end": [10, 3]
      },
      "seriesLabels": {
        "start": [13, 2],
        "end": [13, 5]
      },
      "xLabels": {
        "start": [5, 3],
        "end": [10, 3]
      },
      "xAxisLabel": [13, 2],
      "yAxisLabel": [13, 3]
  },
  "bar": {
      "bodyRows": {
        "start": [5, 4],
        "end": [10, 5]
      },
      "seriesLabels": {
        "start": [13, 2],
        "end": [13, 5]
      },
      "xLabels": {
        "start": [5, 3],
        "end": [10, 3]
      },
      "yAxisLabel": [13, 4]
  }
}

```



